### PR TITLE
Fix verbose usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ node-qunit-phantomjs ./test/fixture.html
 ```
 With options:
 ```bash
-$ node-qunit-phantomjs --verbose ./test/fixture.html
+$ node-qunit-phantomjs ./test/fixture.html --verbose
 ```
 
 Or require it as a module:


### PR DESCRIPTION
`node_modules/.bin/node-qunit-phantomjs --verbose test/index.html` (i.e. verbose option first) results in the following error:

```
path.js:327
        throw new TypeError('Arguments to path.resolve must be strings');
              ^
TypeError: Arguments to path.resolve must be strings
    at Object.exports.resolve (path.js:327:15)
    at module.exports (.../node_modules/node-qunit-phantomjs/index.js:14:29)
    at Object.<anonymous> (.../node_modules/node-qunit-phantomjs/bin/node-qunit-phantomjs:14:36)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:349:32)
    at Function.Module._load (module.js:305:12)
    at Function.Module.runMain (module.js:490:10)
    at startup (node.js:123:16)
    at node.js:1128:3
```

I'm not entirely sure what's going on, except that apparently the argument parsing within the executable goes wrong.
