### PR TITLE
Fixing error when parsing JSON fails. Current check does not ensure valid JSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ module.exports = function (filepath, options, callback) {
                     output;
 
                 stdout.trim().split('\n').forEach(function(line) {
-                    if (line.indexOf('{') !== -1) {
+                    try{
                         out = JSON.parse(line.trim());
                         result = out.result;
 
@@ -58,7 +58,7 @@ module.exports = function (filepath, options, callback) {
                                 console.log('\n' + chalk.red('Test failed') + ': ' + chalk.red(test) + ': \n' + out.exceptions[test].join('\n  '));
                             }
                         }
-                    } else {
+                    } catch(e) {
                         line = line.trim(); // Trim trailing cr-lf
                         console.log(line);
                     }


### PR DESCRIPTION
I was seeing a parse error on an invalid JSON string because it contained an open curly brace. 

failed: {"data" : {"code":1023}}

The current check just sees if there is an open curly brace in the string at all instead of attempting to parse and catching the error. 