### PR TITLE
Introduced a 'customRunner' option for PhantomJS customization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ Default: `5`
 
 Pass a number or string value to override the default timeout of 5 seconds.
 
+
+#### options.customRunner
+
+Type: `String`
+Default: `None`
+
+A path to a custom PhantomJS runner script. A custom runner can be used to have more control over PhantomJS (configuration, hooks, etc.). Default runner implementations are provided by the [PhantomJS Runner QUnit Plugin](https://github.com/jonkemp/qunit-phantomjs-runner).
+
 ## License
 
 MIT © [Jonathan Kemp](http://jonkemp.com)

--- a/index.js
+++ b/index.js
@@ -14,6 +14,10 @@ module.exports = function (filepath, options, callback) {
 
     if (opt.verbose) {
         runner = path.join(phantomjsRunnerDir, 'runner-list.js');
+    } else if (opt.customRunner) {
+        // A custom phantomjs runner can be used to have more control
+        // over phantomjs configuration or to customize phantomjs hooks.
+        runner = opt.customRunner;
     }
 
     var absolutePath = path.resolve(filepath),


### PR DESCRIPTION
Hey,

What do you think about having such an option?
I am using it with a runner writing out a istanbul coverage report.
Instead of forking your whole repository like there
https://github.com/kmudrick/node-qunit-phantomjs-istanbul
IMO it would be cleaner to have such flexibility here.

Cheers,
Oliver